### PR TITLE
use settings.LOGIN_REDIRECT_URL as default

### DIFF
--- a/user_manager/views.py
+++ b/user_manager/views.py
@@ -14,7 +14,8 @@ import requests
 
 
 def login_view(request):
-    next_url = request.GET.get('next', '/')
+    default_redirect = getattr(settings, "LOGIN_REDIRECT_URL", "/")
+    next_url = request.GET.get('next', default_redirect)
     
     if request.user.is_authenticated:
         return redirect(next_url)


### PR DESCRIPTION
After login, was redirecting to "/" when no redirect URL specified in GET request. Instead, should use django setting LOGIN_REDIRECT_URL.